### PR TITLE
Allow for authentification with password or token to jenkins server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ passed in as parameters) is always nice for users too:
       tasks:
         - jenkins_credentials:
             jenkins_url: https://jenkins.mycompany.com/
+            jenkins_username: mylogin
+            jenkins_password: mypassword_or_token
             name: github-https
             cls: com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
             args:

--- a/library/jenkins_api.py
+++ b/library/jenkins_api.py
@@ -4,7 +4,7 @@ from ansible.module_utils.basic import *
 import jenkins
 
 
-def _jenkins_api(jenkins_url=None, command=None, args=None, kwargs=None):
+def _jenkins_api(jenkins_url=None, jenkins_username=None, jenkins_password=None, command=None, args=None, kwargs=None):
 
     result = {
         'cmd': '{} {} {}'.format(jenkins_url, args, kwargs),
@@ -14,7 +14,7 @@ def _jenkins_api(jenkins_url=None, command=None, args=None, kwargs=None):
         'rc': 1
     }
 
-    server = jenkins.Jenkins(jenkins_url)
+    server = jenkins.Jenkins(jenkins_url, jenkins_username, jenkins_password)
 
     if not hasattr(server, command):
         result['msg'] = 'Unknown command: {}'.format(command)
@@ -43,6 +43,8 @@ if __name__ == '__main__':
     module = AnsibleModule(
         argument_spec={
             'jenkins_url': {'required': True},
+            'jenkins_username': {'required': False},
+            'jenkins_password': {'required': False},
             'command': {'required': True},
             'args': {'required': False, 'type': 'list'},
             'kwargs': {'required': False, 'type': 'dict'},


### PR DESCRIPTION
Using jenkins_username and jenkins_password (or token then)

This shouldn't break former implementations not using a password, as it's handled directly as None as python-jenkins defines it anyway.